### PR TITLE
Add Requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ You need to have pip (of course).
 - `python3 -m venv env`
 - `source env/bin/activate`
 - `which python`
-- `pip install fastapi`
-- `pip install uvicorn`
-- `pip install rq`
-- `pip install redis`
+- `pip install -r requirements.txt`
 
 ## How to Run
 ### Running FastAPI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+rq
+redis


### PR DESCRIPTION
Requirements.txt is important to a contributor easily install dependencies running only ```pip install -r requirements.txt``` instead:

```shell
$ pip install ...
...
$ pip install ...
```


Closes #22 